### PR TITLE
Change master branch to main

### DIFF
--- a/nimble.sh
+++ b/nimble.sh
@@ -820,8 +820,8 @@ clone() {
     # set remote
     git remote add -t \* -f origin "$repo"
 
-    # checkout master
-    git checkout -f master
+    # checkout main
+    git checkout -f main
 
     cd $nimble_root
 }


### PR DESCRIPTION
Updates checkout to default to main rather than master to account for most of our projects using `main` branch.